### PR TITLE
Temproary fix for hiding account info

### DIFF
--- a/src/inject/GPMInject/interface/customUI.js
+++ b/src/inject/GPMInject/interface/customUI.js
@@ -35,7 +35,13 @@ window.wait(() => {
   hide('[data-action="upload-music"]');
   hide('[data-action="help-and-feedback"]');
   hide('[data-action="send-gift"]');
+  
+  //Temp Fix: Hiding the entire account details bubble
+  hide('[aria-label="Account Information"]');
+  hide('[class="gb_ab"]');
+  hide('[class="gb_bb"]');
 
+  //Hide Upload Dialog
   hide('.upload-dialog-bg', true);
   hide('.upload-dialog', true);
 


### PR DESCRIPTION
removes the white screen with unreadable text.
downside: fully removes it and doesn't just make the text white and the background black because i don't know jack about CSS

 understandable if you don't want to merge.

also, haven't had a chance to test this, coding on mobile is hard, might want to do that